### PR TITLE
Fix glueton tun management

### DIFF
--- a/.k3d/Dockerfile
+++ b/.k3d/Dockerfile
@@ -1,4 +1,4 @@
-ARG K3S_TAG="v1.31.3-k3s1"
+ARG K3S_TAG="v1.31.2-k3s1"
 FROM rancher/k3s:$K3S_TAG AS k3s
 
 FROM nvidia/cuda:12.6.3-base-ubuntu22.04

--- a/helm/templates/transmission.yaml
+++ b/helm/templates/transmission.yaml
@@ -40,7 +40,6 @@ spec:
             capabilities:
               add:
                 - NET_ADMIN
-            privileged: true
           env:
             - name: VPN_SERVICE_PROVIDER
               value: {{ .Values.vpn.provider.name }}


### PR DESCRIPTION
- Revert making gluetun privleged
- Revert bump to k8s 1.31.3 as this seems to break the `/dev/net/tun` integration